### PR TITLE
Default language config updated

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@ publish = "public"
 command = "zola build"
 
 [build.environment]
-ZOLA_VERSION = "0.10.1"
+ZOLA_VERSION = "0.14.0"
 
 [context.deploy-preview]
 command = "zola build --base-url $DEPLOY_PRIME_URL"

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% import "macros.html" as macro %}
 
 <!DOCTYPE html>
-<html lang="{% if page.extra.lang %}{{ page.extra.lang }}{% else %}{{ config.default_language }}{% endif %}" itemscope itemtype="http://schema.org/Blog">
+<html lang="{% if page.extra.lang %}{{ page.extra.lang }}{% else %}{{ lang }}{% endif %}" itemscope itemtype="http://schema.org/Blog">
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">


### PR DESCRIPTION
Seems Zola has updated the way to access the default
from `config.default_langauge` to just `lang`.